### PR TITLE
A bit closer to working WiFi

### DIFF
--- a/msm8974.mk
+++ b/msm8974.mk
@@ -206,7 +206,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_cfg.dat:system/etc/firmware/wlan/prima/WCNSS_cfg.dat \
     kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_cfg.ini:system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini \
-    kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_wlan_nv.bin:system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
+    kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_wlan_nv.bin:system/etc/firmware/wlan/prima/WCNSS_qcom_wlan_nv.bin
 
 # WPA supplicant config
 PRODUCT_COPY_FILES += \

--- a/msm8974.mk
+++ b/msm8974.mk
@@ -208,6 +208,9 @@ PRODUCT_COPY_FILES += \
     kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_cfg.ini:system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini \
     kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_wlan_nv.bin:system/etc/firmware/wlan/prima/WCNSS_qcom_wlan_nv.bin
 
+PRODUCT_PACKAGES += \
+    wcnss_service
+
 # WPA supplicant config
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/wpa_supplicant.conf:system/etc/wifi/wpa_supplicant.conf \

--- a/msm8974.mk
+++ b/msm8974.mk
@@ -203,10 +203,10 @@ PRODUCT_PACKAGES += \
     libnetcmdiface
 
 # Wifi firmware
-PRODUCT_PACKAGES += \
-    WCNSS_cfg.dat \
-    WCNSS_qcom_cfg.ini \
-    WCNSS_qcom_wlan_nv.bin
+PRODUCT_COPY_FILES += \
+    kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_cfg.dat:system/etc/firmware/wlan/prima/WCNSS_cfg.dat \
+    kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_cfg.ini:system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini \
+    kernel/htc/msm8974/drivers/staging/prima/firmware_bin/WCNSS_qcom_wlan_nv.bin:system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
 
 # WPA supplicant config
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
<6>[    4.916904] c0    554 wcnss_wlan triggered by userspace
<3>[    4.945951] c1    554 wcnss_trigger_config:  adc get failed
<6>[    4.976206] c1    554 pil_pronto fb21b000.qcom,pronto: wcnss: request wcnss_pm_qos_req 
<6>[    4.976221] c1    554 pil_pronto fb21b000.qcom,pronto: wcnss: loading from 0x0d200000 to 0x0d84e000
<6>[    5.299976] c1    554 pil_pronto fb21b000.qcom,pronto: wcnss: Brought out of reset
<6>[    5.563438] c1     93 pil_pronto fb21b000.qcom,pronto: wcnss:  release wcnss_pm_qos_req 
<6>[    5.563448] c1     93 pil_pronto fb21b000.qcom,pronto: wcnss: Power/Clock ready interrupt received
<6>[    5.705774] c0      4 wcnss_wlan_ctrl_probe: SMD ctrl channel up
<6>[    5.706089] c0     24 wcnss: version 01050102
<6>[    5.706100] c0     24 wcnss: schedule dnld work for pronto
<6>[    5.706108] c0     24 wcnss: NV download
<6>[    5.706237] c0      4 wcnss: build version MSM-PR_1_4_c3-1423207
<6>[    5.720091] c0     24 wcnss: NV bin size: 29812, total_fragments: 10
<3>[    5.720120] c0     24 wcnss: no space available for smd frame
<3>[    5.745190] c0     24 wcnss: no space available for smd frame
<3>[    5.775343] c0     24 wcnss: no space available for smd frame
<3>[    5.805225] c0     24 wcnss: no space available for smd frame
<3>[    5.836053] c0     24 wcnss: not setting up vbatt
<6>[   10.245353] c0    219 wakeup sources:  'wcnss'  'radio-interface'  'qpnp-charger-ef8e3800'  'bam_dmux_wakelock'  'mmc1_detect', time left 335 ticks;  'mmc0_detect', time left 334 ticks;  'msm_dwc3' 
<6>[   12.357282] c0    219 wcnss: cal data collection completed
<6>[   15.725145] c0    219 wcnss_post_bootup: Cancel APPS vote for Iris & WCNSS
